### PR TITLE
Configure EtherCalc path in config.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,36 +20,77 @@ for these instructions.
 
 ## Install Ethercalc
 
-1. `sudo apt-get install gzip git curl python libssl-dev pkg-config build-essential`
-2. `sudo npm install -g ethercalc`
-3. Start Ethercalc: `ethercalc`
+```bash
+# install deps
+sudo apt-get install gzip git curl python libssl-dev pkg-config build-essential
+# install ethercalc
+sudo npm install -g ethercalc
+# start ethercalc
+ethercalc
+```
 
 By default, Ethercalc runs on port 8000.
 
 ## Install Apache2
 
-1. Install Apache 2: `sudo apt-get install apache2`
-2. Enable CGI module: `sudo a2enmod cgi`
+```bash
+sudo apt-get install apache2
+# enable CGI module and reload
+sudo a2enmod cgi
+sudo service apache2 restart
+```
 
 ## Install GitDOX
+Decide where you want GitDOX to live under your Apache directories. In these
+instructions we'll assume it's `/var/www/html`
 
-2. Clone GitDOX somewhere Apache can see it, like `/var/www/html`: `git clone https://github.com/gucorpling/gitdox.git /var/www/html`
-3. Allow permission to execute top-level Python files: `sudo chmod +x /var/www/html/*.py`
-4. Edit `/etc/apache2/apache2.conf` and allow Python CGI scripts for the
-   directory you installed GitDOX under:
+1. Install xmllint for xml validation:
+
+```bash
+# install xmllint for xml validation
+sudo apt-get install libxml2-utils
+```
+
+2. Execute the following to set up GitDOX's files:
+
+```bash
+sudo git clone https://github.com/gucorpling/gitdox.git /var/www/html
+
+# change ownership of files
+sudo chown -R www-data:www-data /var/www/html
+
+# allow apache to execute top level python files
+sudo chmod +x /var/www/html/*.py
+
+# install dependencies--use pip
+sudo apt-get install python-pip
+sudo pip install -r /var/www/html/requirements.txt
+```
+
+3. Edit the contents of `users/config.ini` to your liking. In particular, pay
+   attention to `xml_nlp_api` and `spreadsheet_nlp_api` if you plan to make use
+   of those features.
+
+4. Add these lines to `/etc/apache2/apache2.conf`. This tells Apache to execute
+Python files that the client requests, and to serve `index.py` by default:
 
 ```
 <Directory "/var/www/html">
-    Options +ExecCGI
-    AddHandler cgi-script .py
-    DirectoryIndex index.py
+	Options +ExecCGI
+	AddHandler cgi-script .py
+	DirectoryIndex index.py
 </Directory>
 ```
 
-5. Navigate to `localhost/index.py` in a web browser. 
+5. Modify the value of `ether_url` in `paths.py` so that it reflects where
+   GitDOX can find your Ethercalc service over HTTP. By default, it is on your
+   local machine on port 8000, so the line in `paths.py` would read `ether_url =
+   "http://localhost/"`.
 
-(3) using the spreadsheet editor requires an installation of EtherCalc.
+6. Navigate to `http://localhost`. The default login is `admin`, `pass1`.
 
+
+# Credits
 
 (c) 2016-2017 Shuo Zhang (@zangsir) and Amir Zeldes (@amir-zeldes)
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ The editor interface is based on [CodeMirror](https://codemirror.net). GitHub is
 GitDox is used by [Coptic SCRIPTORIUM](http://copticscriptorium.org/) as an xml editor/transcription tool for Coptic texts. 
 
 # Installation
-The following instructions assume you are installing on a recent version of
-Ubuntu.
+The following instructions assume you are installing on a recent (16.04-18.04) version of Ubuntu.
 
 ## Install Redis
 Ethercalc has an optional dependency on Redis. We assume you will be using Redis
@@ -49,7 +48,6 @@ instructions we'll assume it's `/var/www/html`
 1. Install xmllint for xml validation:
 
 ```bash
-# install xmllint for xml validation
 sudo apt-get install libxml2-utils
 ```
 
@@ -94,6 +92,6 @@ Python files that the client requests, and to serve `index.py` by default:
 
 # Credits
 
-(c) 2016-2017 Shuo Zhang (@zangsir) and Amir Zeldes (@amir-zeldes)
+(c) 2016-2017 Shuo Zhang (@zangsir), Amir Zeldes (@amir-zeldes), and Luke Gessler (@lukegessler)
 
 This work was supported by the [KELLIA](http://kellia.uni-goettingen.de/) project, [NEH](https://www.neh.gov/) grant #HG-229371, co-sponsored by the German [DFG](http://www.dfg.de/).

--- a/README.md
+++ b/README.md
@@ -89,10 +89,9 @@ sudo pip install -r /var/www/html/requirements.txt
    attention to `xml_nlp_api` and `spreadsheet_nlp_api` if you plan to make use
    of those features.
 
-4. Modify the value of `ether_url` in `paths.py` so that it reflects where
-   GitDox can find your Ethercalc service over HTTP. By default, it is on your
-   local machine on port 8000, so the line in `paths.py` would read `ether_url =
-   "http://localhost:8000/"`.
+4. Modify the value of `ether_url` in `users/config.ini` so that it reflects where
+   GitDox can find your Ethercalc service over HTTP. By default, GitDox assumes it 
+   is on your local machine on port 8000.
 
 5. Navigate to `http://localhost`. The default login is `admin`, `pass1`.
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Ethercalc has an optional dependency on Redis. We assume you will be using Redis
 for these instructions.
 
 ```bash
-sudo apt-get update
-sudo apt-get install redis-server
+sudo apt update
+sudo apt install redis-server
 redis-cli ping #=> "PONG", if all has gone well
 ```
  
@@ -22,11 +22,11 @@ redis-cli ping #=> "PONG", if all has gone well
 
 ```bash
 # install deps
-sudo apt-get install gzip git curl python libssl-dev pkg-config build-essential
+sudo apt install gzip git curl python libssl-dev pkg-config build-essential npm
 # install ethercalc
 sudo npm install -g ethercalc
-# start ethercalc
-ethercalc
+# start ethercalc in background and continue using terminal
+ethercalc &
 ```
 
 By default, Ethercalc runs on port 8000.
@@ -34,7 +34,7 @@ By default, Ethercalc runs on port 8000.
 ## Install Apache2
 
 ```bash
-sudo apt-get install apache2
+sudo apt install apache2
 # enable CGI module and reload
 sudo a2enmod cgi
 sudo service apache2 restart
@@ -47,7 +47,7 @@ instructions we'll assume it's `/var/www/html`
 1. Install xmllint for xml validation:
 
 ```bash
-sudo apt-get install libxml2-utils
+sudo apt install libxml2-utils
 ```
 
 2. Execute the following to set up GitDox's files:
@@ -62,7 +62,7 @@ sudo chown -R www-data:www-data /var/www/html
 sudo chmod +x /var/www/html/*.py
 
 # install dependencies--use pip
-sudo apt-get install python-pip
+sudo apt install python-pip
 sudo pip install -r /var/www/html/requirements.txt
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,47 @@
 # gitdox
-Repository for GitDOX, a GitHub Data-storage Online XML editor
+GitDOX is an online editor for version controlled XML editing.
 
-This tool is being used by Coptic SCRIPTORIUM as an xml editor/transcription tool for coptic texts. The editor is based on CodeMirror(https://codemirror.net) and uses GitHub as a remote backend, and SQLite for local storage. 
+The editor interface is based on [CodeMirror](https://codemirror.net). GitHub is used as a remote backend, and SQLite is used for local storage. 
 
-To configure on server or localhost, simply download the files, and make sure
+GitDOX is used by [Coptic SCRIPTORIUM](http://copticscriptorium.org/) as an xml editor/transcription tool for Coptic texts. 
 
-(1) you have added handlers for python for the directory in the main Apache config file, like:
+# Installation
+The following instructions assume you are installing on a recent version of
+Ubuntu.
+
+## Install Redis
+Ethercalc has an optional dependency on Redis. We assume you will be using Redis
+for these instructions.
+
+1. `sudo add-apt-repository ppa:rwky/redis`
+2. `sudo apt-get update`
+3. `sudo apt-get install redis-server`
+4. Ensure you get a "PONG" back from Redis: `redis-cli ping`
+
+## Install Ethercalc
+
+1. `sudo apt-get install gzip git curl python libssl-dev pkg-config build-essential`
+2. `sudo npm install -g ethercalc`
+3. Start Ethercalc: `ethercalc`
+
+By default, Ethercalc runs on port 8000.
+
+## Install GitDOX
+
+1. Install Apache 2, if necessary: `sudo apt-get install apache2`
+2. Clone GitDOX somewhere Apache can see it, like `/var/www/html`: `git clone https://github.com/gucorpling/gitdox.git /var/www/html`
+3. Allow permission to execute top-level Python files: `sudo chmod +x /var/www/html/*.py`
+4. Edit `/etc/apache2/apache2.conf` and allow Python CGI scripts for the
+   directory you installed GitDOX under:
 
 <code>
 \<Directory "/Applications/MAMP/htdocs/gitdox"\>
-    
     Options +ExecCGI
-    
     AddHandler cgi-script .py
-
 \</Directory\>
 </code>
 
-(2) you have given executable permission the python scripts.
-
-To start the app, run index.py and log in with admin or your credentials. 
+5. Navigate to `localhost/index.py` in a web browser. 
 
 (3) using the spreadsheet editor requires an installation of EtherCalc.
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ Ubuntu.
 Ethercalc has an optional dependency on Redis. We assume you will be using Redis
 for these instructions.
 
-1. `sudo add-apt-repository ppa:rwky/redis`
-2. `sudo apt-get update`
-3. `sudo apt-get install redis-server`
-4. Ensure you get a "PONG" back from Redis: `redis-cli ping`
-
+```bash
+sudo add-apt-repository ppa:rwky/redis
+sudo apt-get update
+sudo apt-get install redis-server
+redis-cli ping #=> "PONG", if all has gone well
+```
+ 
 ## Install Ethercalc
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -92,6 +92,6 @@ Python files that the client requests, and to serve `index.py` by default:
 
 # Credits
 
-(c) 2016-2017 Shuo Zhang (@zangsir), Amir Zeldes (@amir-zeldes), and Luke Gessler (@lukegessler)
+(c) 2016-2018 Shuo Zhang (@zangsir), Amir Zeldes (@amir-zeldes), and Luke Gessler (@lukegessler)
 
 This work was supported by the [KELLIA](http://kellia.uni-goettingen.de/) project, [NEH](https://www.neh.gov/) grant #HG-229371, co-sponsored by the German [DFG](http://www.dfg.de/).

--- a/README.md
+++ b/README.md
@@ -31,12 +31,30 @@ ethercalc &
 
 By default, Ethercalc runs on port 8000.
 
-## Install Apache2
+## Install and Configure Apache2
+
+Install, and enable CGI module
 
 ```bash
 sudo apt install apache2
 # enable CGI module and reload
 sudo a2enmod cgi
+```
+
+Add these lines to `/etc/apache2/apache2.conf`. This tells Apache to execute
+Python files that the client requests, and to serve `index.py` by default. (Note that we're assuming you're installing GitDox under `/var/www/html`--you should replace this path with the one you're going to install under.)
+
+```xml
+<Directory "/var/www/html">
+	Options +ExecCGI
+	AddHandler cgi-script .py
+	DirectoryIndex index.py
+</Directory>
+```
+
+Restart Apache:
+
+```
 sudo service apache2 restart
 ```
 
@@ -70,23 +88,12 @@ sudo pip install -r /var/www/html/requirements.txt
    attention to `xml_nlp_api` and `spreadsheet_nlp_api` if you plan to make use
    of those features.
 
-4. Add these lines to `/etc/apache2/apache2.conf`. This tells Apache to execute
-Python files that the client requests, and to serve `index.py` by default:
-
-```
-<Directory "/var/www/html">
-	Options +ExecCGI
-	AddHandler cgi-script .py
-	DirectoryIndex index.py
-</Directory>
-```
-
-5. Modify the value of `ether_url` in `paths.py` so that it reflects where
+4. Modify the value of `ether_url` in `paths.py` so that it reflects where
    GitDox can find your Ethercalc service over HTTP. By default, it is on your
    local machine on port 8000, so the line in `paths.py` would read `ether_url =
    "http://localhost/:8000"`.
 
-6. Navigate to `http://localhost`. The default login is `admin`, `pass1`.
+5. Navigate to `http://localhost`. The default login is `admin`, `pass1`.
 
 
 # Credits

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ sudo pip install -r /var/www/html/requirements.txt
 4. Modify the value of `ether_url` in `paths.py` so that it reflects where
    GitDox can find your Ethercalc service over HTTP. By default, it is on your
    local machine on port 8000, so the line in `paths.py` would read `ether_url =
-   "http://localhost/:8000"`.
+   "http://localhost:8000/"`.
 
 5. Navigate to `http://localhost`. The default login is `admin`, `pass1`.
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ sudo rm -rf /var/www/html
 sudo git clone https://github.com/gucorpling/gitdox.git /var/www/html
 sudo chown -R www-data:www-data /var/www/html
 
-# allow apache to execute top level python files
+# allow apache to execute python files
 sudo chmod +x /var/www/html/*.py
+sudo chmod +x /var/www/html/modules/*.py
 
 # install dependencies--use pip
 sudo apt install python-pip

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# gitdox
-GitDOX is an online editor for version controlled XML editing.
+# GitDox
+GitDox is an online editor for version controlled XML editing.
 
 The editor interface is based on [CodeMirror](https://codemirror.net). GitHub is used as a remote backend, and SQLite is used for local storage. 
 
-GitDOX is used by [Coptic SCRIPTORIUM](http://copticscriptorium.org/) as an xml editor/transcription tool for Coptic texts. 
+GitDox is used by [Coptic SCRIPTORIUM](http://copticscriptorium.org/) as an xml editor/transcription tool for Coptic texts. 
 
 # Installation
 The following instructions assume you are installing on a recent version of
@@ -42,8 +42,8 @@ sudo a2enmod cgi
 sudo service apache2 restart
 ```
 
-## Install GitDOX
-Decide where you want GitDOX to live under your Apache directories. In these
+## Install GitDox
+Decide where you want GitDox to live under your Apache directories. In these
 instructions we'll assume it's `/var/www/html`
 
 1. Install xmllint for xml validation:
@@ -53,7 +53,7 @@ instructions we'll assume it's `/var/www/html`
 sudo apt-get install libxml2-utils
 ```
 
-2. Execute the following to set up GitDOX's files:
+2. Execute the following to set up GitDox's files:
 
 ```bash
 sudo git clone https://github.com/gucorpling/gitdox.git /var/www/html
@@ -85,7 +85,7 @@ Python files that the client requests, and to serve `index.py` by default:
 ```
 
 5. Modify the value of `ether_url` in `paths.py` so that it reflects where
-   GitDOX can find your Ethercalc service over HTTP. By default, it is on your
+   GitDox can find your Ethercalc service over HTTP. By default, it is on your
    local machine on port 8000, so the line in `paths.py` would read `ether_url =
    "http://localhost/"`.
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ sudo apt install libxml2-utils
 2. Execute the following to set up GitDox's files:
 
 ```bash
+# clear /var/www/html and clone gitdox to it, changing ownership to www-data
+sudo rm -rf /var/www/html
 sudo git clone https://github.com/gucorpling/gitdox.git /var/www/html
-
-# change ownership of files
 sudo chown -R www-data:www-data /var/www/html
 
 # allow apache to execute top level python files
@@ -84,7 +84,7 @@ Python files that the client requests, and to serve `index.py` by default:
 5. Modify the value of `ether_url` in `paths.py` so that it reflects where
    GitDox can find your Ethercalc service over HTTP. By default, it is on your
    local machine on port 8000, so the line in `paths.py` would read `ether_url =
-   "http://localhost/"`.
+   "http://localhost/:8000"`.
 
 6. Navigate to `http://localhost`. The default login is `admin`, `pass1`.
 

--- a/README.md
+++ b/README.md
@@ -26,20 +26,25 @@ for these instructions.
 
 By default, Ethercalc runs on port 8000.
 
+## Install Apache2
+
+1. Install Apache 2: `sudo apt-get install apache2`
+2. Enable CGI module: `sudo a2enmod cgi`
+
 ## Install GitDOX
 
-1. Install Apache 2, if necessary: `sudo apt-get install apache2`
 2. Clone GitDOX somewhere Apache can see it, like `/var/www/html`: `git clone https://github.com/gucorpling/gitdox.git /var/www/html`
 3. Allow permission to execute top-level Python files: `sudo chmod +x /var/www/html/*.py`
 4. Edit `/etc/apache2/apache2.conf` and allow Python CGI scripts for the
    directory you installed GitDOX under:
 
-<code>
-\<Directory "/Applications/MAMP/htdocs/gitdox"\>
+```
+<Directory "/var/www/html">
     Options +ExecCGI
     AddHandler cgi-script .py
-\</Directory\>
-</code>
+    DirectoryIndex index.py
+</Directory>
+```
 
 5. Navigate to `localhost/index.py` in a web browser. 
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Ethercalc has an optional dependency on Redis. We assume you will be using Redis
 for these instructions.
 
 ```bash
-sudo add-apt-repository ppa:rwky/redis
 sudo apt-get update
 sudo apt-get install redis-server
 redis-cli ping #=> "PONG", if all has gone well

--- a/paths.py
+++ b/paths.py
@@ -1,17 +1,16 @@
 import requests, os, platform
 from modules.configobj import ConfigObj
 
-# URL for ethercalc spreadsheets, possible including authentication
-# e.g. http://mydomain.com/ethercalc/
-# to use password authentication, use a netrc file called .netrc in the project root
-ether_url = "http://mydomain.com/ethercalc/"
-
 # Support IIS site prefix on Windows
 if platform.system() == "Windows":
 	prefix = "transc\\"
 else:
 	prefix = ""
 
+# to use password authentication, use a netrc file called .netrc in the project root
+ether_url = ConfigObj(prefix + "users" + os.sep + "config.ini")["ether_url"]
+if not ether_url.endswith(os.sep):
+    ether_url += os.sep
 
 def get_menu():
 	config = ConfigObj(prefix + "users" + os.sep + "config.ini")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 lxml
 requests
-github3.py
+github3.py=0.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 lxml
 requests
-github3.py=0.9.3
+github3.py==0.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 lxml
+requests
+github3.py

--- a/users/config.ini
+++ b/users/config.ini
@@ -11,6 +11,7 @@ xml_nlp_button = """<i class="fa" style="font-family: antinoouRegular">ⲁ|ϥ</i
 spreadsheet_nlp_button = """<span class="fa fa-stack" style="line-height: 1em; height: 1em"> <i class="fa fa-arrow-right fa-stack-1x" style="left: -8px;"></i> <i class="fa fa-table fa-stack-1x"></i></span> NLP"""
 xml_nlp_api = https://corpling.uis.georgetown.edu/coptic-nlp/api
 spreadsheet_nlp_api = https://corpling.uis.georgetown.edu/coptic-nlp/api
+ether_url = http://localhost:8000
 
 # nlp service credentials
 nlp_user = user


### PR DESCRIPTION
This PR makes paths.py pull `ether_url` out of `config.ini` instead of having it hardcoded.