### PR TITLE
Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM ubuntu:18.04
+EXPOSE 80
+
+# install deps
+RUN apt update
+RUN apt -y install apache2 python python-pip redis-server gzip git curl libssl-dev pkg-config build-essential npm libxml2-utils git
+
+# pull gitdox and give permissions
+RUN rm -rf /var/www/html
+RUN git clone https://github.com/gucorpling/gitdox.git /var/www/html
+RUN chown -R www-data:www-data /var/www/html
+RUN chmod +x /var/www/html/*.py
+RUN chmod +x /var/www/html/modules/*.py
+
+# keep these in sync with requirements.txt
+RUN pip install lxml requests github3.py==0.9.3 passlib
+
+# start ethercalc
+RUN npm install -g ethercalc
+RUN ethercalc &
+
+# enable cgi
+RUN a2enmod cgi
+RUN echo "                       \n \
+<Directory /var/www/html>        \n \
+   Options +ExecCGI              \n \
+   AddHandler cgi-script .py     \n \
+   DirectoryIndex index.py       \n \
+</Directory>                     \n \
+" >> /etc/apache2/apache2.conf
+RUN service apache2 restart
+
+CMD /usr/sbin/apache2ctl -D FOREGROUND

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,12 @@ EXPOSE 80
 
 # install deps
 RUN apt update
-RUN apt -y install apache2 python python-pip redis-server gzip git curl libssl-dev pkg-config build-essential npm libxml2-utils git
+RUN apt -y install apache2 python python-pip redis-server gzip git curl \
+libssl-dev pkg-config build-essential npm libxml2-utils
 
-# pull gitdox and give permissions
+# add gitdox and give permissions
 RUN rm -rf /var/www/html
-RUN git clone https://github.com/gucorpling/gitdox.git /var/www/html
+ADD . /var/www/html
 RUN chown -R www-data:www-data /var/www/html
 RUN chmod +x /var/www/html/*.py
 RUN chmod +x /var/www/html/modules/*.py
@@ -15,9 +16,9 @@ RUN chmod +x /var/www/html/modules/*.py
 # keep these in sync with requirements.txt
 RUN pip install lxml requests github3.py==0.9.3 passlib
 
-# start ethercalc
+# install ethercalc and run as a service
 RUN npm install -g ethercalc
-RUN ethercalc &
+RUN adduser --system --no-create-home --group ethercalc
 
 # enable cgi
 RUN a2enmod cgi
@@ -28,6 +29,25 @@ RUN echo "                       \n \
    DirectoryIndex index.py       \n \
 </Directory>                     \n \
 " >> /etc/apache2/apache2.conf
-RUN service apache2 restart
 
-CMD /usr/sbin/apache2ctl -D FOREGROUND
+RUN a2enmod proxy_html proxy_http proxy_wstunnel
+# set up a proxy for ethercalc
+RUN echo " \n\
+<VirtualHost *:80> \n\
+	ServerName localhost \n\
+\n\
+	# Proxy pass to the node.js server (port 8000) \n\
+	ProxyPass /ethercalc/ http://127.0.0.1:8000/ \n\
+	ProxyPassReverse /ethercalc/ http://127.0.0.1:8000/ \n\
+  ProxyPreserveHost On \n\
+</VirtualHost> \n\
+" >> /etc/apache2/apache2.conf
+
+# against best practices both to (1) not use a different container for each
+# service and (2) not to use supervisord to manage the execution of these
+# processes. But (1) is too heavy a solution, and (2) seems unnecessary unless
+# one of our services leaks memory/is unstable
+RUN echo "/usr/bin/redis-server &" >> /etc/startup.sh
+RUN echo "/usr/local/bin/ethercalc &" >> /etc/startup.sh
+RUN echo "/usr/sbin/apache2ctl -D FOREGROUND" >> /etc/startup.sh
+ENTRYPOINT ["/bin/sh", "/etc/startup.sh"]

--- a/README.md
+++ b/README.md
@@ -6,11 +6,49 @@ The editor interface is based on [CodeMirror](https://codemirror.net). GitHub is
 GitDox is used by [Coptic SCRIPTORIUM](http://copticscriptorium.org/) as an xml editor/transcription tool for Coptic texts. 
 
 # Installation
-You can install GitDox with either Docker or manually on your machine. Unless
-you have a good reason to install manually, we recommend you install GitDox
-using Docker.
+You have three choices:
 
-# Installing with Docker
+1. Pull the latest GitDox Docker image
+2. Build and run a GitDox Docker image
+3. Manually install GitDox on your machine 
+
+Unless you have a good reason to do (2) or (3), we recommend you do (1).
+
+# Pull the latest Docker image
+**Note:** currently, only the `gucorpling/gitdox-dev` image is available. We
+hope to provide a stable release soon.
+
+First, [install Docker](https://docs.docker.com/install/). You may be able to
+install it using your platform's package manager.
+
+```bash
+docker run -dit --restart unless-stopped --name gitdox-dev -p 5000:80 gucorpling/gitdox-dev
+```
+
+GitDox should now be running the docker container you've set up, and you may
+visit `http://localhost:5000` on your machine to verify that it works. GitDox should
+now always be running on your machine, even if you reboot it. If for some reason
+you need to stop it manually, you may do so:
+
+```bash
+docker stop gitdox
+# since you stopped it manually, it will no longer start automatically, even on
+# reboot. to start again:
+docker start gitdox
+```
+
+If for whatever reason you need to manually edit GitDox files, you may start a
+bash session inside of the Docker container:
+
+```bash
+docker exec -it gitdox-instance bash
+# now you are inside--install vim so you can edit files
+apt install vim 
+cd /var/www/html
+vim user/admin.ini # or whatever you need to edit
+```
+
+# Build and run a Docker image
 First, [install Docker](https://docs.docker.com/install/). You may be able to
 install it using your platform's package manager.
 
@@ -21,11 +59,11 @@ git clone https://github.com/gucorpling/gitdox ~/gitdox
 # compile the docker image
 docker build -t gitdox .
 # launch the image on your machine, mapping the image's port 80 to your machine's 80
-docker run -dit --restart unless-stopped --name gitdox -p 80:80 gitdox
+docker run -dit --restart unless-stopped --name gitdox -p 5000:80 gitdox
 ```
 
 GitDox should now be running the docker container you've set up, and you may
-visit `http://localhost` on your machine to verify that it works. GitDox should
+visit `http://localhost:5000` on your machine to verify that it works. GitDox should
 now always be running on your machine, even if you reboot it. If for some reason
 you need to stop it manually, you may do so:
 
@@ -132,8 +170,12 @@ sudo pip install -r /var/www/html/requirements.txt
    of those features.
 
 4. Modify the value of `ether_url` in `users/config.ini` so that it reflects where
-   GitDox can find your Ethercalc service over HTTP. By default, GitDox assumes it 
-   is on your local machine on port 8000.
+   GitDox can find your Ethercalc service over HTTP. It defaults to assuming
+   that you will serve Ethercalc via reverse proxy into a subdirectory of your
+   website, /ethercalc/. If you want to serve it over its original port, you
+   should change it to something like `yourdomain.com:8000`, and if you want to
+   serve it over a subdomain, change it to something like
+   `your.subdomain.yourdomain.com`.
 
 5. Navigate to `http://localhost`. The default login is `admin`, `pass1`.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,48 @@ The editor interface is based on [CodeMirror](https://codemirror.net). GitHub is
 GitDox is used by [Coptic SCRIPTORIUM](http://copticscriptorium.org/) as an xml editor/transcription tool for Coptic texts. 
 
 # Installation
+You can install GitDox with either Docker or manually on your machine. Unless
+you have a good reason to install manually, we recommend you install GitDox
+using Docker.
+
+# Installing with Docker
+First, [install Docker](https://docs.docker.com/install/). You may be able to
+install it using your platform's package manager.
+
+Run the following code:
+
+```bash
+git clone https://github.com/gucorpling/gitdox ~/gitdox
+# compile the docker image
+docker build -t gitdox .
+# launch the image on your machine, mapping the image's port 80 to your machine's 80
+docker run -dit --restart unless-stopped --name gitdox -p 80:80 gitdox
+```
+
+GitDox should now be running the docker container you've set up, and you may
+visit `http://localhost` on your machine to verify that it works. GitDox should
+now always be running on your machine, even if you reboot it. If for some reason
+you need to stop it manually, you may do so:
+
+```bash
+docker stop gitdox
+# since you stopped it manually, it will no longer start automatically, even on
+# reboot. to start again:
+docker start gitdox
+```
+
+If for whatever reason you need to manually edit GitDox files, you may start a
+bash session inside of the Docker container:
+
+```bash
+docker exec -it gitdox-instance bash
+# now you are inside--install vim so you can edit files
+apt install vim 
+cd /var/www/html
+vim user/admin.ini # or whatever you need to edit
+```
+
+# Manual Installation
 The following instructions assume you are installing on a recent (16.04-18.04) version of Ubuntu.
 
 ## Install Redis
@@ -89,10 +131,9 @@ sudo pip install -r /var/www/html/requirements.txt
    attention to `xml_nlp_api` and `spreadsheet_nlp_api` if you plan to make use
    of those features.
 
-4. Modify the value of `ether_url` in `paths.py` so that it reflects where
-   GitDox can find your Ethercalc service over HTTP. By default, it is on your
-   local machine on port 8000, so the line in `paths.py` would read `ether_url =
-   "http://localhost:8000/"`.
+4. Modify the value of `ether_url` in `users/config.ini` so that it reflects where
+   GitDox can find your Ethercalc service over HTTP. By default, GitDox assumes it 
+   is on your local machine on port 8000.
 
 5. Navigate to `http://localhost`. The default login is `admin`, `pass1`.
 

--- a/users/config.ini
+++ b/users/config.ini
@@ -5,13 +5,13 @@ skin = css/scriptorium.css
 project = Scriptorium
 banner = http://copticscriptorium.org/nav.html
 cookiepath = "" # the 'super-url' of the scripts - for the cookie. Can be '' if no other script in your domain uses cookies
-adminuser = admin# the login name who is the *main* administrator account. This one cannot be deleted.
+adminuser = admin # the login name who is the *main* administrator account. This one cannot be deleted.
 editor_help_link = <p>For help getting started see the <a target="_wiki" href="http://wiki.copticscriptorium.org/doku.php?id=gitdox_workflow">wiki</a></p>
 xml_nlp_button = """<i class="fa" style="font-family: antinoouRegular">ⲁ|ϥ</i> Tokenize"""
 spreadsheet_nlp_button = """<span class="fa fa-stack" style="line-height: 1em; height: 1em"> <i class="fa fa-arrow-right fa-stack-1x" style="left: -8px;"></i> <i class="fa fa-table fa-stack-1x"></i></span> NLP"""
 xml_nlp_api = https://corpling.uis.georgetown.edu/coptic-nlp/api
 spreadsheet_nlp_api = https://corpling.uis.georgetown.edu/coptic-nlp/api
-ether_url = http://localhost:8000
+ether_url = /ethercalc/
 
 # nlp service credentials
 nlp_user = user


### PR DESCRIPTION
This PR introduces [a Dockerfile](https://github.com/gucorpling/gitdox/blob/10fad56c46c7b95d806260603ad8dc01bf22e74a/Dockerfile) and tells users [how to install GitDox](https://github.com/gucorpling/gitdox/blob/10fad56c46c7b95d806260603ad8dc01bf22e74a/README.md#installing-with-docker) by manually making a Docker image on their local machine.

Ultimately, we'll probably want to publish a pre-compiled image on [Docker Hub](https://hub.docker.com/) so users will be able to get going with just one command. I've used my personal account in the mean time [to host an image](https://hub.docker.com/r/lgessler/gitdox-dev/). So you can get going with this one magic incantation:

```bash
docker run -dit --restart unless-stopped --name gitdox-dev -p 5000:80 gucorpling/gitdox-dev
```

It should now be running on localhost:5000. See the [updated readme](https://github.com/gucorpling/gitdox/blob/10fad56c46c7b95d806260603ad8dc01bf22e74a/README.md#installing-with-docker) for more information.