### PR TITLE
Export validation

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -30,7 +30,6 @@ scriptpath = os.path.dirname(os.path.realpath(__file__)) + os.sep
 userdir = scriptpath + "users" + os.sep
 templatedir = scriptpath + "templates" + os.sep
 config = ConfigObj(userdir + 'config.ini')
-skin = config["skin"]
 project = config["project"]
 
 
@@ -244,9 +243,6 @@ def load_admin(user, admin, theform):
 	if sql_statements > 0:
 		render_data["sql_statements"] = sql_statements
 
-	render_data["navbar_html"] = get_menu()
-	render_data["skin_stylesheet"] = skin
-
 	return render("admin", render_data)
 
 
@@ -265,8 +261,6 @@ def load_user_config(user, admin, theform):
 
 	render_data['user'] = user
 	render_data['admin_eq_one'] = admin == "1"
-	render_data["navbar_html"] = get_menu()
-	render_data["skin_stylesheet"] = skin
 
 	return render("user_admin", render_data)
 

--- a/css/gitdox.css
+++ b/css/gitdox.css
@@ -172,7 +172,7 @@ width: 100%}
 }
 
 #validation_report{
-    height: 300px;
+    height: 200px;
     overflow-y: auto;
 }
 

--- a/editor.py
+++ b/editor.py
@@ -30,7 +30,6 @@ scriptpath = os.path.dirname(os.path.realpath(__file__)) + os.sep
 userdir = scriptpath + "users" + os.sep
 templatedir = scriptpath + "templates" + os.sep
 config = ConfigObj(userdir + 'config.ini')
-skin = config["skin"]
 project = config["project"]
 editor_help_link = config["editor_help_link"]
 # Captions and API URLs for NLP buttons
@@ -488,9 +487,7 @@ def load_page(user,admin,theform):
 		render_data["github_push_html"] = push_git
 
 	render_data["can_save"] = not (int(admin) < 3)
-	render_data["navbar_html"] = get_menu()
 	render_data["editor_help_link_html"] = editor_help_link
-	render_data["skin_stylesheet"] = skin
 
 	return render("editor", render_data)
 

--- a/editor.py
+++ b/editor.py
@@ -150,15 +150,6 @@ def load_page(user,admin,theform):
 					else:
 						update_assignee(doc_id, assignee)
 
-			if theform.getvalue('edit_schema') and user != "demo":
-				schema = theform.getvalue('edit_schema')
-				if schema != "--none--":
-					if doc_id > max_id:
-						create_document(doc_id, docname, corpus, status, assignee, repo_name, text_content)
-						max_id = doc_id
-					else:
-						update_schema(doc_id, schema)
-
 			# cloning metadata from an existing doc into a new doc
 			if theform.getvalue('source_doc'):
 				source_meta = get_doc_meta(theform.getvalue('source_doc'))
@@ -237,10 +228,6 @@ def load_page(user,admin,theform):
 				mode = theform.getvalue('edit_mode')
 				if mode != old_mode and user != "demo":
 					update_mode(doc_id,mode)
-			if theform.getvalue('edit_schema'):
-				schema = theform.getvalue('edit_schema')
-				if schema != old_schema and user != "demo":
-					update_schema(doc_id, schema)
 			if theform.getvalue('nlp_spreadsheet') == "do_nlp_spreadsheet":  # mode has been changed to spreadsheet via NLP
 				update_mode(doc_id, "ether")
 				mode = "ether"
@@ -350,24 +337,6 @@ def load_page(user,admin,theform):
 
 	edit_status += options+"</select>"
 
-	# Get XML schema list
-	schema_list = ['--none--']
-	scriptpath = os.path.dirname(os.path.realpath(__file__)) + os.sep
-	schemadir = scriptpath + "schemas" + os.sep
-
-	schema_list += get_file_list(schemadir,"xsd",hide_extension=True)
-
-	edit_schema = """<select name="edit_schema" onchange="do_save();">"""
-	for schema_file in schema_list:
-		schema_select = ""
-		schema_name = schema_file
-		if schema_name == schema:
-			schema_select = "selected"
-		edit_schema += """<option value='""" + schema_name + "' %s>" + schema_name + """</option>"""
-		edit_schema = edit_schema % schema_select
-	edit_schema += "</select>"
-	# edit_schema = edit_schema.replace(schema+'"', schema+'" selected="selected"')
-
 	# Get user_list from the logintools
 	user_list=[]
 	scriptpath = os.path.dirname(os.path.realpath(__file__)) + os.sep
@@ -461,7 +430,6 @@ def load_page(user,admin,theform):
 	render_data['repo'] = repo_name
 
 	render_data['edit_status_html'] = edit_status
-	render_data['edit_schema_html'] = edit_schema
 	render_data['edit_assignee_html'] = edit_assignee
 	render_data['edit_mode_html'] = edit_mode
 	render_data['metadata_html'] = print_meta(doc_id)

--- a/editor.py
+++ b/editor.py
@@ -419,7 +419,12 @@ def load_page(user,admin,theform):
 	else:
 		render_data['ether_mode'] = False
 
-	render_data['doc_is_selected'] = len(doc_id) != 0
+	# stop here if no doc selected
+	if doc_id:
+		render_data['doc_is_selected'] = len(doc_id) != 0
+	else:
+		return render("editor", render_data)
+
 	render_data['id'] = doc_id
 	render_data['mode'] = mode
 	render_data['schema'] = schema

--- a/index.py
+++ b/index.py
@@ -93,15 +93,9 @@ def load_landing(user, admin, theform):
 	render_data['docs'] = []
 	for doc in doc_list:
 		doc_vars = {}
-		for item in doc:
-			if item == "xml":
-				doc_vars["xml"] = True
-				mode = "xml"
-			elif item == "ether":
-				doc_vars["ether"] = True
-				mode = "ether"
-			elif "-" in str(item):
-				doc_vars["other_mode"] = True
+		doc_vars["xml"] = "xml" in doc
+		doc_vars["ether"] = "ether" in doc
+		doc_vars["other_mode"] = not (doc_vars["xml"] or doc_vars["ether"])
 
 		id = str(doc[0])
 		doc_vars["id"] = id

--- a/index.py
+++ b/index.py
@@ -114,13 +114,11 @@ def load_landing(user, admin, theform):
 	render_data["admin_gt_zero"] = int(admin) > 0
 	render_data["admin_eq_three"] = admin == "3"
 	render_data["max_id_plus1"] = str(max_id + 1)
-	render_data["navbar_html"] = get_menu().encode("utf8")
 	render_data["user"] = user
 
 	scriptpath = os.path.dirname(os.path.realpath(__file__)) + os.sep
 	userdir = scriptpath + "users" + os.sep
 	config = ConfigObj(userdir + 'config.ini')
-	render_data["skin_stylesheet"] = config["skin"]
 	render_data["project"] = config["project"]
 
 	return render("index", render_data)

--- a/js/index.js
+++ b/js/index.js
@@ -9,17 +9,23 @@ function validate_all() {
         success: function(response) {
             console.log(response);
             $.each(response, function(key, value) {
-                // 1 vs 2 is for ordering ether/xml before metadata
+                // 1 vs 2 is for ordering ether/xml before metadata, 3 is used for export
                 // sort is hidden text at beginning of cell for sorting purposes
                 var output1 = '';
                 var output2 = '';
+                var output3 = '';
                 var sort1 = '';
                 var sort2 = '';
+                var sort3 = '';
                 $.each(value, function(k,v) {
                     if (k == "ether") {
-                        if (v == "spreadsheet is valid") {
+                        if (v.indexOf("EtherCalc is valid") > -1) {
                             color = 'green';
                             sort1 = 'v';
+                        }
+                        else if (v.indexOf("no applicable") > -1) {
+                            color = 'gray';
+                            sort1 = 'n';
                         }
                         else {
                             color = 'red';
@@ -28,9 +34,13 @@ function validate_all() {
                         output1 += '<div class="tooltip" style="display:inline-block"><i class="fa fa-table" style="color:' + color + '">&nbsp;</i><span>' + v + '</span></div>';
                     }
                     else if (k == "meta") {
-                        if (v == "metadata is valid") {
+                        if (v.indexOf("metadata is valid") > -1) {
                             color = 'green';
                             sort2 = 'v';
+                        }
+                        else if (v.indexOf("no applicable") > -1) {
+                            color = 'gray';
+                            sort2 = 'n';
                         }
                         else {
                             color = 'red';
@@ -39,11 +49,11 @@ function validate_all() {
                         output2 += '<div class="tooltip" style="display:inline-block"><i class="fa fa-tags" style="color:' + color + '">&nbsp;</i><span>' + v + '</span></div>';
                     }
                     else if (k == "xml") {
-                        if (v.indexOf("validates") !== -1) {
+                        if (v.indexOf("xml is valid") > -1) {
                             color = 'green';
                             sort1 = 'v';
                         }
-                        else if (v == "No schema<br/>") {
+                        else if (v.indexOf("no applicable") > -1) {
                             color = 'gray';
                             sort1 = 'n';
                         }
@@ -53,9 +63,27 @@ function validate_all() {
                         }
                         output1 += '<div class="tooltip" style="display:inline-block"><i class="fa fa-code" style="color:' + color + '">&nbsp;</i><span>' + v + '</span></div>';
                     }
+                    else if (k == "export") {
+                        if (v.indexOf("exports are valid") > -1) {
+                            color = 'green';
+                            sort3 = 'v';
+                        }
+                        else if (v.indexOf("no applicable") > -1) {
+                            color = 'gray';
+                            sort3 = 'n';
+                        }
+                        else {
+                            color = 'red';
+                            sort3 = 'i';
+                        }
+                        output3 += '<div class="tooltip" style="display:inline-block"><i class="fa fa-file" style="color:' + color + '">&nbsp;</i><span>' + v + '</span></div>';
+                    }
                 });
-                $("#validate_"+key).before("<i hidden>" + sort1 + sort2 + "</i>");
-                $("#validate_"+key).html(output1 + output2);
+                if (!output3) {
+                    output3 = '<div class="tooltip" style="display:inline-block"><i class="fa fa-file" style="visibility:hidden;">&nbsp;</i><span> </span></div>';
+                }
+                $("#validate_"+key).before("<i hidden>" + sort1 + sort2 + sort3 + "</i>");
+                $("#validate_"+key).html(output1 + output2 + output3);
             });
             $("#validate_landing").removeClass("disabledbutton");
             $("#validate_landing").html('<i class="fa fa-check"></i> re-validate');

--- a/js/validation_rules.js
+++ b/js/validation_rules.js
@@ -4,12 +4,13 @@ $(document).ready(function () {
         sorting: true,
         actions: {
             listAction: function (postData, jtParams) {
+                jtParams.domain = 'xml';
                 return $.Deferred(function ($dfd) {
                     $.ajax({
                         url: 'modules/jtable_rule_list.py',
                         type: 'POST',
                         dataType: 'json',
-                        data: {domain: "xml"},
+                        data: jtParams,
                         success: function (data) {
                             $dfd.resolve(data);
                         },
@@ -55,12 +56,13 @@ $(document).ready(function () {
         sorting: true,
         actions: {
             listAction: function (postData, jtParams) {
+                jtParams.domain = 'meta';
                 return $.Deferred(function ($dfd) {
                     $.ajax({
                         url: 'modules/jtable_rule_list.py',
                         type: 'POST',
                         dataType: 'json',
-                        data: {domain: "meta"},
+                        data: jtParams,
                         success: function (data) {
                             $dfd.resolve(data);
                         },
@@ -112,12 +114,13 @@ $(document).ready(function () {
         sorting: true,
         actions: {
             listAction: function (postData, jtParams) {
+                jtParams.domain = 'ether';
                 return $.Deferred(function ($dfd) {
                     $.ajax({
                         url: 'modules/jtable_rule_list.py',
                         type: 'POST',
                         dataType: 'json',
-                        data: {domain: "ether"},
+                        data: jtParams,
                         success: function (data) {
                             $dfd.resolve(data);
                         },
@@ -169,12 +172,13 @@ $(document).ready(function () {
         sorting: true,
         actions: {
             listAction: function (postData, jtParams) {
+                jtParams.domain = 'export';
                 return $.Deferred(function ($dfd) {
                     $.ajax({
                         url: 'modules/jtable_rule_list.py',
                         type: 'POST',
                         dataType: 'json',
-                        data: {domain: "export"},
+                        data: jtParams,
                         success: function (data) {
                             $dfd.resolve(data);
                         },

--- a/js/validation_rules.js
+++ b/js/validation_rules.js
@@ -1,9 +1,24 @@
 $(document).ready(function () {
-    $('#ValidationTableContainer').jtable({
-        title: 'Validation Rules',
+    $('#xml-table-container').jtable({
+        title: 'XML Validation Rules',
         sorting: true,
         actions: {
-            listAction: 'modules/jtable_rule_list.py',
+            listAction: function (postData, jtParams) {
+                return $.Deferred(function ($dfd) {
+                    $.ajax({
+                        url: 'modules/jtable_rule_list.py',
+                        type: 'POST',
+                        dataType: 'json',
+                        data: {domain: "xml"},
+                        success: function (data) {
+                            $dfd.resolve(data);
+                        },
+                        error: function() {
+                            $dfd.reject();
+                        }
+                    });
+                });
+            },
             createAction: 'modules/jtable_create_rule.py',
             updateAction: 'modules/jtable_update_rule.py',
             deleteAction: 'modules/jtable_delete_rule.py'
@@ -11,7 +26,13 @@ $(document).ready(function () {
         fields: {
             id: {
                 title: 'ID',
-                key: true
+                key: true,
+                visibility:'hidden'
+            },
+            domain: {
+                title: 'Domain',
+                options: ['xml'],
+                visibility: 'hidden'
             },
             doc: {
                 title: 'Document'
@@ -19,9 +40,113 @@ $(document).ready(function () {
             corpus: {
                 title: 'Corpus'
             },
+            name: {
+                title: 'XSD Schema',
+                options: 'modules/jtable_schema_list.py?extension=xsd'
+            }
+        }
+    });
+    $('#xml-table-container').jtable('load');
+});
+
+$(document).ready(function () {
+    $('#meta-table-container').jtable({
+        title: 'Metadata Validation Rules',
+        sorting: true,
+        actions: {
+            listAction: function (postData, jtParams) {
+                return $.Deferred(function ($dfd) {
+                    $.ajax({
+                        url: 'modules/jtable_rule_list.py',
+                        type: 'POST',
+                        dataType: 'json',
+                        data: {domain: "meta"},
+                        success: function (data) {
+                            $dfd.resolve(data);
+                        },
+                        error: function() {
+                            $dfd.reject();
+                        }
+                    });
+                });
+            },
+            createAction: 'modules/jtable_create_rule.py',
+            updateAction: 'modules/jtable_update_rule.py',
+            deleteAction: 'modules/jtable_delete_rule.py'
+        },
+        fields: {
+            id: {
+                title: 'ID',
+                key: true,
+                visibility:'hidden'
+            },
             domain: {
                 title: 'Domain',
-                options: ['ether', 'meta']
+                options: ['meta'],
+                visibility: 'hidden'
+            },
+            doc: {
+                title: 'Document'
+            },
+            corpus: {
+                title: 'Corpus'
+            },
+            name: {
+                title: 'Name'
+            },
+            operator: {
+                title: 'Operator',
+                options: ['~', 'exists']
+            },
+            argument: {
+                title: 'Argument'
+            }
+        }
+    });
+    $('#meta-table-container').jtable('load');
+});
+
+$(document).ready(function () {
+    $('#ether-table-container').jtable({
+        title: 'EtherCalc Validation Rules',
+        sorting: true,
+        actions: {
+            listAction: function (postData, jtParams) {
+                return $.Deferred(function ($dfd) {
+                    $.ajax({
+                        url: 'modules/jtable_rule_list.py',
+                        type: 'POST',
+                        dataType: 'json',
+                        data: {domain: "ether"},
+                        success: function (data) {
+                            $dfd.resolve(data);
+                        },
+                        error: function() {
+                            $dfd.reject();
+                        }
+                    });
+                });
+            },
+            createAction: 'modules/jtable_create_rule.py',
+            updateAction: 'modules/jtable_update_rule.py',
+            deleteAction: 'modules/jtable_delete_rule.py'
+        },
+        fields: {
+            id: {
+                title: 'ID',
+                key: true,
+                visibility:'hidden'
+            },
+            domain: {
+                title: 'Domain',
+                options: ['ether'],
+                visibility: 'hidden'
+            },
+            doc: {
+                title: 'Document'
+            },
+            corpus: {
+                title: 'Corpus'
             },
             name: {
                 title: 'Name'
@@ -35,5 +160,60 @@ $(document).ready(function () {
             }
         }
     });
-    $('#ValidationTableContainer').jtable('load');
+    $('#ether-table-container').jtable('load');
+});
+
+$(document).ready(function () {
+    $('#export-table-container').jtable({
+        title: 'Export Validation Rules',
+        sorting: true,
+        actions: {
+            listAction: function (postData, jtParams) {
+                return $.Deferred(function ($dfd) {
+                    $.ajax({
+                        url: 'modules/jtable_rule_list.py',
+                        type: 'POST',
+                        dataType: 'json',
+                        data: {domain: "export"},
+                        success: function (data) {
+                            $dfd.resolve(data);
+                        },
+                        error: function() {
+                            $dfd.reject();
+                        }
+                    });
+                });
+            },
+            createAction: 'modules/jtable_create_rule.py',
+            updateAction: 'modules/jtable_update_rule.py',
+            deleteAction: 'modules/jtable_delete_rule.py'
+        },
+        fields: {
+            id: {
+                title: 'ID',
+                key: true,
+                visibility:'hidden'
+            },
+            domain: {
+                title: 'Domain',
+                options: ['export'],
+                visibility: 'hidden'
+            },
+            doc: {
+                title: 'Document'
+            },
+            corpus: {
+                title: 'Corpus'
+            },
+            name: {
+                title: 'Export Spec',
+                options: 'modules/jtable_schema_list.py?extension=ini'
+            },
+            argument: {
+                title: 'XSD Schema',
+                options: 'modules/jtable_schema_list.py?extension=xsd'
+            }
+        }
+    });
+    $('#export-table-container').jtable('load');
 });

--- a/modules/gitdox_sql.py
+++ b/modules/gitdox_sql.py
@@ -211,11 +211,17 @@ def get_corpora():
 def get_validate_rules():
 		return generic_query("SELECT corpus, doc, domain, name, operator, argument, id FROM validate", None)
 
+def get_xml_rules():
+	return generic_query("SELECT corpus, doc, domain, name, operator, argument, id FROM validate WHERE domain = 'xml'", None)
+
 def get_meta_rules():
 	return generic_query("SELECT corpus, doc, domain, name, operator, argument, id FROM validate WHERE domain = 'meta'", None)
 
 def get_ether_rules():
 	return generic_query("SELECT corpus, doc, domain, name, operator, argument, id FROM validate WHERE domain = 'ether'", None)
+
+def get_export_rules():
+	return generic_query("SELECT corpus, doc, domain, name, operator, argument, id FROM validate WHERE domain = 'export'", None)
 
 def get_sorted_rules(sort):
 	return generic_query("SELECT corpus, doc, domain, name, operator, argument, id FROM validate ORDER BY " + sort, None)  # parameterization doesn't work for order by

--- a/modules/jtable_rule_list.py
+++ b/modules/jtable_rule_list.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 
 from gitdox_sql import *
 import json
@@ -11,12 +11,17 @@ def list_rules():
 	try:
 		parameter = cgi.FieldStorage()
 		sort = parameter.getvalue("jtSorting")
+		domain_filter = parameter.getvalue("domain")
 		if sort is not None:
 			rules = get_sorted_rules(sort)
 		else:
 			rules = get_validate_rules()
+
 		json_rules = []
 		for rule in rules:
+			if domain_filter and rule[2] != domain_filter:
+				continue
+
 			new_json_rule = {}
 			new_json_rule['corpus'] = rule[0]
 			new_json_rule['doc'] = rule[1]

--- a/modules/jtable_schema_list.py
+++ b/modules/jtable_schema_list.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from gitdox_sql import *
+import json
+import cgi
+import os
+
+schema_dir = (os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+              + os.sep
+              + 'schemas')
+
+def list_files():
+	jtable_result = {}
+	ext = cgi.FieldStorage().getvalue("extension")
+
+	try:
+		options = [{"DisplayText": x,
+                    "Value": x}
+                   for x in os.listdir(schema_dir)
+                   if x.endswith(ext)]
+		jtable_result['Result'] = 'OK'
+		jtable_result['Options'] = options
+		return json.dumps(jtable_result)
+	except:
+		jtable_result['Result'] = 'Error'
+		jtable_result['Message'] = 'Something went wrong in jtable_xsd_list.py'
+		return json.dumps(jtable_result)
+
+
+print "Content-type:application/json\r\n\r\n"
+print list_files()

--- a/modules/renderer.py
+++ b/modules/renderer.py
@@ -1,11 +1,17 @@
 import platform
 import os
+from modules.configobj import ConfigObj
+from paths import get_menu
 from pystache.renderer import Renderer
 
+import cgitb; cgitb.enable()
 if platform.system() == "Windows":
 	prefix = "transc\\"
 else:
 	prefix = ""
+rootpath = os.path.dirname(os.path.dirname(os.path.realpath(__file__))) + os.sep
+userdir = rootpath + "users" + os.sep
+config = ConfigObj(userdir + 'config.ini')
 
 def render(template_name, variables, template_dir='templates', file_ext=".mustache"):
     """
@@ -28,4 +34,6 @@ def render(template_name, variables, template_dir='templates', file_ext=".mustac
                                     if filename.endswith(file_ext)])
     renderer = Renderer(partials=partials)
 
+    variables['skin_stylesheet'] = config['skin']
+    variables['navbar_html'] = get_menu()
     return renderer.render_path(prefix + template_dir + os.sep + template_name + file_ext, variables)

--- a/modules/validation/ether_validator.py
+++ b/modules/validation/ether_validator.py
@@ -248,13 +248,14 @@ class EtherValidator(Validator):
 
         if self.corpus is not None:
             if re.search(self.corpus, doc_corpus) is None:
-                return res
+                return res, False
         if self.doc is not None:
             if re.search(self.doc, doc_name) is None:
-                return res
+                return res, False
 
         report, tooltip, cells = self._apply_rule(parsed_ether)
+
         res['report'] += report
         res['tooltip'] += tooltip
         res['cells'] += cells
-        return res
+        return res, True

--- a/modules/validation/export_validator.py
+++ b/modules/validation/export_validator.py
@@ -1,14 +1,16 @@
 from validator import Validator
-from ..ether import exec_via_temp
+from ..ether import exec_via_temp, ExportConfig, ether_to_sgml
 import re
 
-class XmlValidator(Validator):
+# TODO: would have been ideal to write this without any filesystem operations
+class ExportValidator(Validator):
     def __init__(self, rule):
         self.corpus = rule[0]
         self.doc = rule[1]
-        self.schema = rule[3]
+        self.config = rule[3]
+        self.schema = rule[5]
 
-    def validate(self, doc, doc_name, doc_corpus):
+    def validate(self, socialcalc, doc_id, doc_name, doc_corpus):
         report = ""
 
         if self.corpus is not None:
@@ -18,9 +20,11 @@ class XmlValidator(Validator):
             if re.search(self.doc, doc_name) is None:
                 return report, False
 
+        export_data = ether_to_sgml(socialcalc, doc_id, config=self.config)
+
         schema = self.schema
         command = "xmllint --schema schemas/" + schema + " tempfilename"
-        out, err = exec_via_temp(doc, command)
+        out, err = exec_via_temp(export_data, command)
         err = err.strip()
         err = err.replace("<br>","").replace("\n","").replace('<h1 align="center">xmllint output</h1>',"")
         err = re.sub(r'/tmp/[A-Za-z0-9_]+:','XML schema: <br>',err)
@@ -29,6 +33,7 @@ class XmlValidator(Validator):
         if err == "XML schema  validates":
             report = ""
         else:
-            report = "Problems validating with " + self.schema + ":<br>" + err + "<br>"
+            report = "Problems with exporting with " + self.config \
+                     + " and validating with " + self.schema + ":<br>" + err + "<br>"
 
         return report, True

--- a/modules/validation/legacy_xml_validator.py
+++ b/modules/validation/legacy_xml_validator.py
@@ -1,0 +1,26 @@
+from validator import Validator
+from ..ether import exec_via_temp
+import re
+
+# TODO: would have been ideal to write this without any filesystem operations
+class LegacyXmlValidator(Validator):
+    def __init__(self, schema):
+        self.schema = schema
+
+    def validate(self, doc):
+        report = ""
+
+        if self.schema == '--none--':
+            return report
+        else:
+            schema = self.schema
+            command = "xmllint --htmlout --schema schemas/" + schema + ".xsd tempfilename"
+            out, err = exec_via_temp(doc, command)
+            err = err.strip()
+            err = err.replace("<br>","").replace("\n","").replace('<h1 align="center">xmllint output</h1>',"")
+            err = re.sub(r'/tmp/[A-Za-z0-9]+:','XML schema: <br>',err)
+            err = re.sub(r'/tmp/[A-Za-z0-9]+','XML schema ',err)
+            err = re.sub(r'\n','<br/>',err)
+            report += err + "<br/>"
+
+        return report

--- a/modules/validation/meta_validator.py
+++ b/modules/validation/meta_validator.py
@@ -44,11 +44,10 @@ class MetaValidator(Validator):
     def validate(self, metadata, doc_name, doc_corpus):
         if self.corpus is not None:
             if re.search(self.corpus, doc_corpus) is None:
-                return ""
+                return {"report": "", "tooltip": ""}, False
         if self.doc is not None:
             if re.search(self.doc, doc_name) is None:
-                return ""
+                return {"report": "", "tooltip": ""}, False
 
         report, tooltip = self._apply_rule(metadata)
-        return {"report": report,
-                "tooltip": tooltip}
+        return {"report": report, "tooltip": tooltip}, True

--- a/modules/validation/xml_validator.py
+++ b/modules/validation/xml_validator.py
@@ -2,25 +2,30 @@ from validator import Validator
 from ..ether import exec_via_temp
 import re
 
-# TODO: would have been ideal to write this without any filesystem operations
 class XmlValidator(Validator):
-    def __init__(self, schema):
-        self.schema = schema
+    def __init__(self, rule):
+        self.corpus = rule[0]
+        self.doc = rule[1]
+        self.schema = rule[3]
 
-    def validate(self, doc):
+    def validate(self, doc, doc_name, doc_corpus):
         report = ""
 
-        if self.schema == '--none--':
-            report += "No schema <br/>"
-        else:
-            schema = self.schema
-            command = "xmllint --htmlout --schema schemas/" + schema + ".xsd tempfilename"
-            out, err = exec_via_temp(doc, command)
-            err = err.strip()
-            err = err.replace("<br>","").replace("\n","").replace('<h1 align="center">xmllint output</h1>',"")
-            err = re.sub(r'/tmp/[A-Za-z0-9]+:','XML schema: <br>',err)
-            err = re.sub(r'/tmp/[A-Za-z0-9]+','XML schema ',err)
-            err = re.sub(r'\n','<br/>',err)
-            report += err + "<br/>"
+        if self.corpus is not None:
+            if re.search(self.corpus, doc_corpus) is None:
+                return report
+        if self.doc is not None:
+            if re.search(self.doc, doc_name) is None:
+                return report
+
+        schema = self.schema
+        command = "xmllint --htmlout --schema schemas/" + schema + " tempfilename"
+        out, err = exec_via_temp(doc, command)
+        err = err.strip()
+        err = err.replace("<br>","").replace("\n","").replace('<h1 align="center">xmllint output</h1>',"")
+        err = re.sub(r'/tmp/[A-Za-z0-9]+:','XML schema: <br>',err)
+        err = re.sub(r'/tmp/[A-Za-z0-9]+','XML schema ',err)
+        err = re.sub(r'\n','<br/>',err)
+        report += err + "<br/>"
 
         return report

--- a/templates/editor.mustache
+++ b/templates/editor.mustache
@@ -126,12 +126,6 @@
                                     </td>
                                 </tr>
                                 <tr>
-                                    <td>XML Schema:</td>
-                                    <td>
-                                        {{{edit_schema_html}}}
-                                    </td>
-                                </tr>
-                                <tr>
                                     <td>Assigned to:</td>
                                     <td>
                                         {{{edit_assignee_html}}}

--- a/templates/editor.mustache
+++ b/templates/editor.mustache
@@ -154,7 +154,7 @@
                         {{/ether_mode}}
 
                         <h3>Metadata</h3>
-                        {{{metadata}}}
+                        {{{metadata_html}}}
 
                         <input type="hidden" name="metakey">
                         <input type="hidden" name="metavalue">

--- a/templates/index.mustache
+++ b/templates/index.mustache
@@ -194,9 +194,15 @@
                                     <i class="fa fa-code" title="xml">&nbsp;</i>
                                     {{/xml}}
                                     {{#ether}}
-                                    <i class="fa fa-code" title="spreadsheet">&nbsp;</i>
+                                    <i class="fa fa-table" title="spreadsheet">&nbsp;</i>
                                     {{/ether}}
                                     <i class="fa fa-tags" title="metadata" style="display:inline-block">&nbsp;</i>
+                                    {{#ether}}
+                                    <i class="fa fa-file" title="export">&nbsp;</i>
+                                    {{/ether}}
+                                    {{^ether}}
+                                    <i class="fa fa-file" title="hidden" style="visibility:hidden;">&nbsp;</i>
+                                    {{/ether}}
                                 </div>
                             </td>
 

--- a/templates/index.mustache
+++ b/templates/index.mustache
@@ -193,9 +193,9 @@
                                     {{#xml}}
                                     <i class="fa fa-code" title="xml">&nbsp;</i>
                                     {{/xml}}
-                                    {{#xml}}
+                                    {{#ether}}
                                     <i class="fa fa-code" title="spreadsheet">&nbsp;</i>
-                                    {{/xml}}
+                                    {{/ether}}
                                     <i class="fa fa-tags" title="metadata" style="display:inline-block">&nbsp;</i>
                                 </div>
                             </td>

--- a/templates/index.mustache
+++ b/templates/index.mustache
@@ -202,13 +202,11 @@
 
                             <!-- edit button -->
                             <td style="text-align:center;">
-                                <form action="editor.py" method="post" id="form_edit_{{id}}">
-                                    <input type="hidden" name="id" value="{{id}}">
-                                    <div onclick="document.getElementById('form_edit_{{id}}').submit();"
-                                         class="button">
+                                <a href="editor.py?id={{id}}" style="color:black;">
+                                    <div class="button">
                                         <i class="fa fa-pencil-square-o"></i> edit
                                     </div>
-                                </form>
+                                </a>
                             </td>
 
                             <!-- delete button -->

--- a/templates/validation_rules.mustache
+++ b/templates/validation_rules.mustache
@@ -33,9 +33,38 @@
             </div>
             <div id="content">
                 <h1>GitDox - Validation</h1>
-                <p style="border-bottom:groove;"><i>validation rule management</i> | <a href="index.py">back to document list</a> </p>
+                <p style="border-bottom:groove;">
+                    <i>validation rule management</i> | <a href="index.py">back to document list</a>
+                </p>
 
-                <div id="ValidationTableContainer"></div>
+                <style>
+                .jtable-title {
+                    font-size: 16px !important;
+                    border: none !important;
+                    border-radius: 0 !important;
+                    background: #eeeeee !important;
+                }
+                table.jtable {
+                    border: none !important;
+                }
+
+                .ui-widget-overlay {
+                    opacity: 0.5 !important;
+                }
+                </style>
+
+                <div style="padding-bottom: 32px;">
+                    <div id="xml-table-container"></div>
+                </div>
+                <div style="padding-bottom: 32px;">
+                    <div id="meta-table-container"></div>
+                </div>
+                <div style="padding-bottom: 32px;">
+                    <div id="ether-table-container"></div>
+                </div>
+                <div style="padding-bottom: 32px;">
+                    <div id="export-table-container"></div>
+                </div>
             </div>
         </div>
     </body>

--- a/validation_rules.py
+++ b/validation_rules.py
@@ -9,23 +9,8 @@ from modules.configobj import ConfigObj
 from modules.renderer import render
 from paths import get_menu
 
-# Support IIS site prefix on Windows
-if platform.system() == "Windows":
-	prefix = "transc\\"
-else:
-	prefix = ""
-
-scriptpath = os.path.dirname(os.path.realpath(__file__)) + os.sep
-userdir = scriptpath + "users" + os.sep
-templatedir = scriptpath + "templates" + os.sep
-config = ConfigObj(userdir + 'config.ini')
-skin = config["skin"]
-project = config["project"]
-
 def load_validation_rules():
 	render_data = {}
-	render_data['navbar_html'] = get_menu()
-	render_data['skin_stylesheet'] = skin
 	return render("validation_rules", render_data)
 
 def open_main_server():


### PR DESCRIPTION
- Move XML validation into rule framework
- Modify validation rules panel so rules are split into tables by kind (still need to make this tabbed--coming soon in a different PR)
- Allow validation of exports for a given export config-xsd combo (no script support yet, but could be added easily)
- Fix the edit button so it supports opening in tabs