### PR TITLE
Make metadata editing async in editor.py

### DIFF
--- a/css/gitdox.css
+++ b/css/gitdox.css
@@ -198,6 +198,22 @@ ul.tabs li.current{
     display: inherit;
 }
 
+/* override jtable styles for consistency with rest of gitdox */
+.jtable-title {
+    font-size: 16px !important;
+    border: none !important;
+    border-radius: 0 !important;
+    background: #eeeeee !important;
+}
+table.jtable {
+    border: none !important;
+}
+
+.ui-widget-overlay {
+    opacity: 0.5 !important;
+}
+
+
 .jtable td{
     word-break: break-all;
 }

--- a/css/gitdox.css
+++ b/css/gitdox.css
@@ -164,8 +164,39 @@ padding: 10px;
 	height: 12.8px;
 }
 
-#ValidationTableContainer{
-width: 100%}
+/* for validation_rules */
+ul.tabs{
+    margin: 0px;
+    padding: 0px;
+    list-style: none;
+}
+
+ul.tabs li{
+    background: none;
+    display: inline-block;
+    padding: 10px 15px;
+    cursor: pointer;
+    min-width: 100px;
+    font-size: 18px;
+    font-weight: 600;
+    color: #222;
+    text-align: center;
+}
+
+ul.tabs li.current{
+    background: #ededed;
+    color: #222;
+}
+
+.tab-content{
+    display: none;
+    background: #ededed;
+    padding: 15px;
+}
+
+.tab-content.current{
+    display: inherit;
+}
 
 .jtable td{
     word-break: break-all;

--- a/js/editor.js
+++ b/js/editor.js
@@ -44,3 +44,54 @@ function export_ether(){
 
     window.open('export.py?docs=' + doc_id + '&stylesheet=' + stylesheet, '_new');
 }
+
+$(document).ready(function () {
+    // get id from hidden form element. Watch out, might break in the future
+    var docid = $("#id").val();
+    $('#metadata-table-container').jtable({
+        title: 'Metadata',
+        sorting: true,
+        actions: {
+            listAction: function (postData, jtParams) {
+                jtParams.domain = 'meta';
+                return $.Deferred(function ($dfd) {
+                    $.ajax({
+                        url: 'modules/editor_metadata.py?action=list&docid=' + docid,
+                        type: 'POST',
+                        dataType: 'json',
+                        data: jtParams,
+                        success: function (data) {
+                            $dfd.resolve(data);
+                        },
+                        error: function() {
+                            $dfd.reject();
+                        }
+                    });
+                });
+            },
+            createAction: 'modules/editor_metadata.py?action=create',
+            deleteAction: 'modules/editor_metadata.py?action=delete&docid=' + docid
+        },
+        fields: {
+            id: {
+                title: 'ID',
+                key: true,
+                visibility:'hidden'
+            },
+            docid: {
+                title: 'Document ID',
+                defaultValue: docid,
+                type: 'hidden'
+            },
+            key: {
+                title: 'Key',
+                options: 'modules/editor_metadata.py?action=keys'
+            },
+            value: {
+                title: 'Value'
+            }
+        }
+    });
+    $('#metadata-table-container').jtable('load');
+});
+

--- a/js/validation_rules.js
+++ b/js/validation_rules.js
@@ -221,3 +221,15 @@ $(document).ready(function () {
     });
     $('#export-table-container').jtable('load');
 });
+
+$(document).ready(function(){
+    $('ul.tabs li').click(function(){
+        var tab_id = $(this).attr('data-tab');
+
+        $('ul.tabs li').removeClass('current');
+        $('.tab-content').removeClass('current');
+
+        $(this).addClass('current');
+        $("#"+tab_id).addClass('current');
+    });
+});

--- a/modules/editor_metadata.py
+++ b/modules/editor_metadata.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from gitdox_sql import *
+import json
+import cgi
+import os
+import platform
+
+parameter = cgi.FieldStorage()
+action = parameter.getvalue("action")
+id = parameter.getvalue("id")
+docid = parameter.getvalue("docid")
+key = parameter.getvalue("key")
+value = parameter.getvalue("value")
+
+if platform.system() == "Windows":
+    prefix = "transc\\"
+else:
+    prefix = ""
+
+def read_options(**kwargs):
+	if "file" in kwargs:
+		kwargs["file"] = prefix + kwargs["file"]
+		names = open(kwargs["file"],'r').read().replace("\r","").split("\n")
+		names = list(name[:name.find("\t")] for name in names)
+	elif "names" in kwargs:
+		names = kwargs[names]
+	selected = kwargs["selected"] if "selected" in kwargs else None
+	return names
+
+def row_to_dict(row):
+    return {'id': row[1],
+            'docid': row[0],
+            'key': row[2],
+            'value': row[3]}
+
+def get_metadata():
+    resp = {}
+    try:
+        resp['Result'] = 'OK'
+        resp['Records'] = [row_to_dict(r) for r in get_doc_meta(docid)]
+        print json.dumps(resp)
+    except:
+        resp['Result'] = 'Error'
+        resp['Message'] = 'Could not fetch metadata'
+        print json.dumps(resp)
+
+def get_default_key_options():
+    resp = {}
+    try:
+        resp['Result'] = 'OK'
+        resp['Options'] = read_options(file='..' + os.sep + 'metadata_fields.tab')
+        print json.dumps(resp)
+    except:
+        resp['Result'] = 'Error'
+        resp['Message'] = 'Could not fetch metadata key options'
+        print json.dumps(resp)
+
+def create_metadata():
+    resp = {}
+    try:
+        save_meta(int(docid), key.decode("utf8"), value.decode("utf8"))
+        resp['Result'] = 'OK'
+        resp['Record'] = {'docid': docid,
+                          'key': key,
+                          'value': value}
+        print json.dumps(resp)
+    except:
+        resp['Result'] = 'Error'
+        resp['Message'] = 'Could not create metadata'
+        print json.dumps(resp)
+
+def delete_metadata():
+    resp = {}
+    try:
+        delete_meta(int(id), int(docid))
+        resp['Result'] = 'OK'
+        print json.dumps(resp)
+    except:
+        resp['Result'] = 'Error'
+        resp['Message'] = 'Could not delete metadata'
+        print json.dumps(resp)
+
+print "Content-type:application/json\r\n\r\n"
+if action == "list":
+    get_metadata()
+elif action == "create":
+    create_metadata()
+elif action == "delete":
+    delete_metadata()
+elif action == "keys":
+    get_default_key_options()
+else:
+    print json.dumps({'Result': 'Error',
+                      'Message': 'Unknown action: "' + str(action) + '"'})

--- a/templates/editor.mustache
+++ b/templates/editor.mustache
@@ -14,28 +14,18 @@
     <script src="js/jquery-1.11.3.min.js"></script>
     <script src="js/editor.js?version=4"></script>
 
+    <!-- for jtable -->
+    <link rel="stylesheet" href="js/jquery-ui-1.12.1/jquery-ui.min.css"/>
+    <link rel="stylesheet" href="js/jtable.2.4.0/themes/lightcolor/gray/jtable.min.css" type="text/css" />
+    <script src="js/jquery-ui-1.12.1/jquery-ui.min.js" type="text/javascript"></script>
+    <script src="js/jtable.2.4.0/jquery.jtable.min.js" type="text/javascript"></script>
+
     <!--The following script tag downloads a font from the Adobe Edge Web Fonts server for use within the web page. We recommend that you do not modify it.-->
     <script>var __adobewebfontsappname__="dreamweaver"</script>
-    <link rel="stylesheet" href="https://use.edgefonts.net/c/dbcb1c/1w;asul,2,WXx:W:n4/l" media="all"><script src="https://use.edgefonts.net/asul:n4:default.js" type="text/javascript"></script>
-
-
-    <style>
-     table {
-         font-family: arial, sans-serif;
-         border-collapse: collapse;
-         width:400pt;
-     }
-
-     td, th {
-         border: 1px solid #dddddd;
-         text-align: left;
-         padding: 8px;
-     }
-
-    </style>
+    <link rel="stylesheet" href="https://use.edgefonts.net/c/dbcb1c/1w;asul,2,WXx:W:n4/l" media="all">
+    <script src="https://use.edgefonts.net/asul:n4:default.js" type="text/javascript"></script>
 
     <script src="js/validate.js"></script>
-
 </head>
 <body>
     {{{navbar_html}}}
@@ -153,8 +143,7 @@
                             {{> codemirror}}
                         {{/ether_mode}}
 
-                        <h3>Metadata</h3>
-                        {{{metadata_html}}}
+                        <div id="metadata-table-container" style="max-width: 1000px;margin: 18px 0;"></div>
 
                         <input type="hidden" name="metakey">
                         <input type="hidden" name="metavalue">

--- a/templates/validation_rules.mustache
+++ b/templates/validation_rules.mustache
@@ -37,23 +37,6 @@
                     <a href="index.py"><i class="fa fa-arrow-left"></i> return to index</a>
                 </p>
 
-                <!-- override jtable styles for aesthetic consistency -->
-                <style>
-                .jtable-title {
-                    font-size: 16px !important;
-                    border: none !important;
-                    border-radius: 0 !important;
-                    background: #eeeeee !important;
-                }
-                table.jtable {
-                    border: none !important;
-                }
-
-                .ui-widget-overlay {
-                    opacity: 0.5 !important;
-                }
-                </style>
-
                 <ul class="tabs">
                     <li data-tab="xml-table-container" class="tab-link current">XML</li>
                     <li data-tab="meta-table-container" class="tab-link">Metadata</li>

--- a/templates/validation_rules.mustache
+++ b/templates/validation_rules.mustache
@@ -32,11 +32,12 @@
                 {{> header}}
             </div>
             <div id="content">
-                <h1>GitDox - Validation</h1>
-                <p style="border-bottom:groove;">
-                    <i>validation rule management</i> | <a href="index.py">back to document list</a>
+                <h1>GitDox - Validation Rules</h1>
+                <p style="margin-bottom:24px;">
+                    <a href="index.py"><i class="fa fa-arrow-left"></i> return to index</a>
                 </p>
 
+                <!-- override jtable styles for aesthetic consistency -->
                 <style>
                 .jtable-title {
                     font-size: 16px !important;
@@ -53,17 +54,17 @@
                 }
                 </style>
 
+                <ul class="tabs">
+                    <li data-tab="xml-table-container" class="tab-link current">XML</li>
+                    <li data-tab="meta-table-container" class="tab-link">Metadata</li>
+                    <li data-tab="ether-table-container" class="tab-link">EtherCalc</li>
+                    <li data-tab="export-table-container" class="tab-link">Export</li>
+                </ul>
                 <div style="padding-bottom: 32px;">
-                    <div id="xml-table-container"></div>
-                </div>
-                <div style="padding-bottom: 32px;">
-                    <div id="meta-table-container"></div>
-                </div>
-                <div style="padding-bottom: 32px;">
-                    <div id="ether-table-container"></div>
-                </div>
-                <div style="padding-bottom: 32px;">
-                    <div id="export-table-container"></div>
+                    <div id="xml-table-container" class="tab-content current"></div>
+                    <div id="meta-table-container" class="tab-content"></div>
+                    <div id="ether-table-container" class="tab-content"></div>
+                    <div id="export-table-container" class="tab-content"></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
-Use the same strategy as in validation_rules.py:
  - Use JTable
  - Use a separate py file in `modules` (`modules/editor_metadata.py`) to handle AJAXes
- One (big?) caveat: as this code stands, it does *not* let you use metadata keys that are not listed in `metadata_fields.tab`. Is this a problem?