### PR TITLE
Expose exception traceback to users

### DIFF
--- a/editor.py
+++ b/editor.py
@@ -6,6 +6,7 @@
 from six import iteritems
 import cgi, cgitb
 import os, shutil
+import sys, traceback
 from modules.logintools import login
 import urllib
 from modules.gitdox_sql import *
@@ -330,7 +331,6 @@ def load_page(user,admin,theform):
                                   'disabled': user == "demo" or mode == "ether"}
 	render_data['git_2fa'] = git_2fa == "true"
 	if git_status:
-		# Remove some html keyword symbols in the commit message returned by github3
 		render_data['git_commit_response'] = git_status.replace('<','').replace('>','')
 
 
@@ -406,8 +406,15 @@ def open_main_server():
 	admin = userconfig["admin"]
 
 	print("Content-type:text/html\n\n")
-	print(load_page(user, admin, theform).encode("utf8"))
-
+	try:
+		print(load_page(user, admin, theform).encode("utf8"))
+	except Exception as e:
+		print("""<html><body><h1>Loading Error</h1>
+		<p>For some reason, this page failed to load.</p>
+		<p>Please send this to your system administrator:</p>
+		<pre>""")
+		traceback.print_exc(e, file=sys.stdout)
+		print("""</pre></body></html>""")
 
 if __name__ == "__main__":
 	open_main_server()

--- a/index.py
+++ b/index.py
@@ -4,6 +4,7 @@
 # Import modules for CGI handling
 import cgi, cgitb
 import os
+import sys, traceback
 from os import listdir
 from modules.logintools import login
 from modules.configobj import ConfigObj
@@ -108,7 +109,15 @@ def open_main_server():
 	admin = userconfig["admin"]
 
 	print("Content-type:text/html\n\n")
-	print(load_landing(user, admin, theform))
+	try:
+		print(load_landing(user, admin, theform))
+	except Exception as e:
+		print("""<html><body><h1>Loading Error</h1>
+		<p>For some reason, this page failed to load.</p>
+		<p>Please send this to your system administrator:</p>
+		<pre>""")
+		traceback.print_exc(e, file=sys.stdout)
+		print("""</pre></body></html>""")
 
 
 if __name__ == '__main__':

--- a/templates/login/login_page.html
+++ b/templates/login/login_page.html
@@ -1,59 +1,52 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+		<head>
+				<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+				<title>GitDox - Login</title>
+				<link rel="stylesheet" href="**skin**" type="text/css" charset="utf-8"/>
+				<link rel="stylesheet" href="css/gitdox.css" type="text/css" charset="utf-8"/>
+				<link rel="stylesheet" href="css/font-awesome-4.7.0/css/font-awesome.min.css"/>
+				<script>var __adobewebfontsappname__="dreamweaver"</script>
+				<link rel="stylesheet" href="https://use.edgefonts.net/c/dbcb1c/1w;asul,2,WXx:W:n4/l" media="all"><script src="https://use.edgefonts.net/asul:n4:default.js" type="text/javascript"></script>
+				<meta charset="UTF-8"/>
+				<meta name="viewport" content="width=800">
+				<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+				<link rel="icon" href="favicon.ico" type="image/x-icon">	
+		</head>
 
-	<title>GitDox - Login</title>
-		<link rel="stylesheet" href="**skin**" type="text/css" charset="utf-8"/>
-		<link rel="stylesheet" href="css/gitdox.css" type="text/css" charset="utf-8"/>
-		<link rel="stylesheet" href="css/font-awesome-4.7.0/css/font-awesome.min.css"/>
-<script>var __adobewebfontsappname__="dreamweaver"</script>
-<link rel="stylesheet" href="https://use.edgefonts.net/c/dbcb1c/1w;asul,2,WXx:W:n4/l" media="all"><script src="https://use.edgefonts.net/asul:n4:default.js" type="text/javascript"></script>
-		<meta charset="UTF-8"/>
-		<meta name="viewport" content="width=800">
-		<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
-		<link rel="icon" href="favicon.ico" type="image/x-icon">	
-</head>
+		<body id="home">
+				<div id="wrapper">
+						<div id="content" style="height: 280px !important; min-height: 100px !important">
+								<div class="banner">
+										<table>
+												<tr>
+														<td rowspan="2">
+																<a href="open.py">
+																		<img src="img/login_logo.png" alt="GitDox" class="logo" height="80px"/>
+																</a>
+														</td>
+														<td class="logged_in">
+																&nbsp;
+														</td>
+												</tr>
+												<tr>
+														<td><h1>GitDox - Login</h1></td>
+												</tr>
+										</table>
+								</div>
+								<br>
 
-<body id="home">
-	<div id="wrapper">
+								**login form**
 
-		<div id="content" style="height:200px !important; min-height: 100px !important">
-<div class="banner">
-<table>
-    <tr>
-<td rowspan="2"><a href="open.py"><img src="img/login_logo.png" alt="GitDox" class="logo" height="80px"/></a></td>
-                <td style="height: 21px; font-size: 16px">&nbsp;
-    </td>
-            <td class="logged_in">
-                &nbsp;
-            </td>
-</tr>
-    <tr>
-<td><h1>GitDox - Login</h1></td>
+								**login failed**
 
-</tr></table>
-</div>
+								<br>
 
-
-<br>
-
-
-**login form**
-
-**login failed**
-
-<br>
-
-
-<!--
-<p>Alternatively <a href="**new login link**">click on this link</a> to create a new login.</p>
--->
-<br>
-</div>
-
-
-<br>
-</div>
-</div>
-</body>
+								<!--
+										 <p>Alternatively <a href="**new login link**">click on this link</a> to create a new login.</p>
+								-->
+								<br>
+						</div>
+						<br>
+				</div>
+		</body>
 </html>

--- a/validate.py
+++ b/validate.py
@@ -3,6 +3,7 @@
 
 from collections import defaultdict
 import re, sys
+import traceback
 import cgi, cgitb
 import json
 
@@ -301,7 +302,15 @@ if __name__ == "__main__":
 		print validate_all_docs().encode("utf8")
 	else:
 		print "Content-type:text/html\n\n"
-		if mode == "ether":
-			print validate_doc_ether(doc_id, editor=True).encode("utf8")
-		elif mode == "xml":
-			print validate_doc_xml(doc_id, schema, editor=True).encode("utf8")
+		try:
+			if mode == "ether":
+				print validate_doc_ether(doc_id, editor=True).encode("utf8")
+			elif mode == "xml":
+				print validate_doc_xml(doc_id, schema, editor=True).encode("utf8")
+		except Exception as e:
+			print("""<html><body><h1>Loading Error</h1>
+			<p>For some reason, this page failed to load.</p>
+			<p>Please send this to your system administrator:</p>
+			<pre>""")
+			traceback.print_exc(e, file=sys.stdout)
+			print("""</pre></body></html>""")


### PR DESCRIPTION
This is a cheap fix that'll help users figure out what might be going wrong, in lieu of a more comprehensive error-handling strategy. The top-level print statements in validate.py, index.py, and editor.py are wrapped in a try/catch that prints the exception if any is thrown in the course of execution. (Before this change, a blank page would be shown.)

Also cleaned up the HTML in login_page.html, it had a few small issues.