### PR TITLE
Fix redis caching when multiple GitDox instances share a Redis instance

### DIFF
--- a/modules/redis_cache.py
+++ b/modules/redis_cache.py
@@ -1,4 +1,7 @@
+import os
+import platform
 import redis
+from modules.configobj import ConfigObj
 
 r = redis.Redis()
 GITDOX_PREFIX = "__gitdox"
@@ -6,13 +9,23 @@ SEP = "|"
 REPORT = "report"
 TIMESTAMP = "timestamp"
 
+if platform.system() == "Windows":
+        prefix = "transc\\"
+else:
+        prefix = ""
+rootpath = os.path.dirname(os.path.dirname(os.path.realpath(__file__))) + os.sep
+userdir = rootpath + "users" + os.sep
+config = ConfigObj(userdir + 'config.ini')
+PROJECT_NAME = "_" + (config['project'].lower().replace(" ", "_") if 'project' in config else 'default_project')
+
+
 def make_key_base(doc_id, validation_type):
     """Keys for this cache have the form, e.g., __gitdox|123|ether|report
     This function formats the first three pieces of this string."""
     if validation_type not in ["xml", "ether", "meta", "export"]:
         raise Exception("Unknown validation type: " + validation_type)
 
-    return SEP.join([GITDOX_PREFIX, str(doc_id), validation_type])
+    return SEP.join([GITDOX_PREFIX, PROJECT_NAME str(doc_id), validation_type])
 
 # common ------------------------------------------------------------------------
 def get_report(doc_id, validation_type):

--- a/modules/redis_cache.py
+++ b/modules/redis_cache.py
@@ -25,7 +25,7 @@ def make_key_base(doc_id, validation_type):
     if validation_type not in ["xml", "ether", "meta", "export"]:
         raise Exception("Unknown validation type: " + validation_type)
 
-    return SEP.join([GITDOX_PREFIX, PROJECT_NAME str(doc_id), validation_type])
+    return SEP.join([GITDOX_PREFIX, PROJECT_NAME, str(doc_id), validation_type])
 
 # common ------------------------------------------------------------------------
 def get_report(doc_id, validation_type):

--- a/modules/redis_cache.py
+++ b/modules/redis_cache.py
@@ -20,8 +20,8 @@ PROJECT_NAME = "_" + (config['project'].lower().replace(" ", "_") if 'project' i
 
 
 def make_key_base(doc_id, validation_type):
-    """Keys for this cache have the form, e.g., __gitdox|123|ether|report
-    This function formats the first three pieces of this string."""
+    """Keys for this cache have the form, e.g., __gitdox|_gum|123|ether|report
+    This function formats the first four pieces of this string."""
     if validation_type not in ["xml", "ether", "meta", "export"]:
         raise Exception("Unknown validation type: " + validation_type)
 


### PR DESCRIPTION
This was done by adding the GitDox project name to the base key for Redis entries.